### PR TITLE
NEW Create GitHub Action for adding PRs to the new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# GitHub Actions - Add PR to project
+
+Add community-created pull requests to the [Community Contributions project](https://github.com/orgs/silverstripe/projects/4) when they're opened.
+
+## Usage
+
+**.github/workflows/add-pr-to-project.yml**
+```yml
+name: Add new pull requests to a github project
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+
+permissions: {}
+
+jobs:
+  addprtoproject:
+    # Only run on the silverstripe account
+    if: github.repository_owner == 'silverstripe'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to github project
+        uses: silverstripe/add-pr-to-project@v1
+```
+
+This action has no inputs.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,44 @@
+name: Add pull request to project
+description: GitHub Action to add new pull requests to the Community Contributions GitHub project
+
+runs:
+  using: composite
+  steps:
+
+    - name: Check if should be added
+      id: check-if-should-add
+      env:
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        IS_DRAFT: ${{ github.event.pull_request.draft }}
+      run: |
+        if [[ $IS_DRAFT == 'true' ]]; then
+            echo "PR is draft. Skipping."
+            echo "should_add_to_project=false" >> $GITHUB_OUTPUT
+            exit 0
+        fi
+        # We don't want CMS Squad member PRs to clutter the project board
+        echo "Author is $PR_AUTHOR"
+        for squad_member in 'GuySartorelli' 'emteknetnz' 'maxime-rainville'; do
+          if [[ $PR_AUTHOR == $squad_member ]]; then
+            echo "Author is in CMS Squad. Skipping."
+            echo "should_add_to_project=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+        done
+        echo "should_add_to_project=true" >> $GITHUB_OUTPUT
+
+    - name: Generate token
+      id: generate-token
+      if: steps.check-if-should-add.outputs.should_add_to_project == 'true' && github.repository_owner == 'silverstripe'
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ vars.PROJECT_PERMISSIONS_APP_ID }}
+        private-key: ${{ secrets.PROJECT_PERMISSIONS_APP_PRIVATE_KEY }}
+  
+    - name: Add to project
+      if: steps.check-if-should-add.outputs.should_add_to_project == 'true'
+      uses: actions/add-to-project@v1.0.1
+      with:
+        # Add to the Community Contributions project
+        project-url: https://github.com/orgs/silverstripe/projects/4
+        github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This action follows the [docs for using GitHub Actions to add PRs to a project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions).

There is a GitHub App which holds read-only access for issues and PRs, and write access to projects. This action uses that app to generate a token, then uses the official GitHub Action for adding PRs to the project.

We are explicitly ignoring PRs created by the CMS Squad, because the project board is for community contributions. We don't want to waste community time reviewing and merging the CMS Squad PRs when we're already being paid to do that ourselves.

## Issue
- https://github.com/silverstripe/.github/issues/155