### PR TITLE
FIX Add missing 'shell' property to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ runs:
 
     - name: Check if should be added
       id: check-if-should-add
+      shell: bash
       env:
         PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         IS_DRAFT: ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/actions/runs/9539113403/job/26289076597?pr=1780

> Error: silverstripe/gha-add-pr-to-project/v1/action.yml (Line: 8, Col: 7): Required property is missing: shell

The same CI run is also complaining about the use of `vars` and `secrets` - but I checked and double checked, and those are being used as per documentation, so I'm hoping the parser just got confused after hitting this initial problem.

## Issue
- https://github.com/silverstripe/.github/issues/155