### PR TITLE
FIX Use inputs for variables and secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Add PR to github project
         uses: silverstripe/add-pr-to-project@v1
+        with:
+          app_id: ${{ vars.MY_APP_ID }}
+          private_key: ${{ secrets.MY_PRIVATE_KEY }}
 ```
 
 This action has no inputs.

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,14 @@
 name: Add pull request to project
 description: GitHub Action to add new pull requests to the Community Contributions GitHub project
 
+inputs:
+  app_id:
+    description: 'The ID for a GitHub App, used to generate a token'
+    required: true
+  private_key:
+    description: 'The private key for a GitHub App, used to generate a token'
+    required: true
+
 runs:
   using: composite
   steps:
@@ -33,8 +41,8 @@ runs:
       if: steps.check-if-should-add.outputs.should_add_to_project == 'true' && github.repository_owner == 'silverstripe'
       uses: actions/create-github-app-token@v1
       with:
-        app-id: ${{ vars.PROJECT_PERMISSIONS_APP_ID }}
-        private-key: ${{ secrets.PROJECT_PERMISSIONS_APP_PRIVATE_KEY }}
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.private_key }}
   
     - name: Add to project
       if: steps.check-if-should-add.outputs.should_add_to_project == 'true'


### PR DESCRIPTION
Apparently you can't use those contexts directly in a composite action. ~Frustratingly I can't find any docs that state that explicitly, though I have seen it on a few stackoverflow answers, and the `runs` key is conspicuously missing from the [context availability docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability).~

The [docs for the secrets context](https://docs.github.com/en/actions/learn-github-actions/contexts#secrets-context) state:
> The secrets context is not available for composite actions due to security reasons. If you want to pass a secret to a composite action, you need to do it explicitly as an input.

I didn't see any similar warning under the `vars` context docs, but presumably it has the same restriction.


## Issue
- https://github.com/silverstripe/.github/issues/155