### PR TITLE
MNT Run module-standardiser

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -1,0 +1,11 @@
+name: Action CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  actionci:
+    name: Action CI
+    uses: silverstripe/gha-action-ci/.github/workflows/action-ci.yml@v1

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,18 @@
+name: Auto-tag
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  auto-tag:
+    name: Auto-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Auto-tag
+        uses: silverstripe/gha-auto-tag@v1

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,21 @@
+name: Keepalive
+
+on:
+  # At 3:15 PM UTC, on day 4 of the month
+  schedule:
+    - cron: '15 15 4 * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  keepalive:
+    name: Keepalive
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Keepalive
+        uses: silverstripe/gha-keepalive@v1

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -1,0 +1,22 @@
+name: Merge-up
+
+on:
+  # At 6:30 AM UTC, only on Friday
+  schedule:
+    - cron: '30 6 * * 5'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  merge-up:
+    name: Merge-up
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Merge-up
+        uses: silverstripe/gha-merge-up@v1

--- a/.github/workflows/tag-patch-release.yml
+++ b/.github/workflows/tag-patch-release.yml
@@ -1,0 +1,27 @@
+name: Tag patch release
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      latest_local_sha:
+        description: The latest local sha
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  tagpatchrelease:
+    name: Tag patch release
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Tag release
+        uses: silverstripe/gha-tag-release@v2
+        with:
+          latest_local_sha: ${{ inputs.latest_local_sha }}
+          dispatch_gha_autotag: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Silverstripe Limited - www.silverstripe.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This pull-request was created automatically by [module-standardiser](https://github.com/silverstripe/module-standardiser)

Turns out we only did this on the `1` branch before, which resulted in this CI failure: https://github.com/silverstripe/gha-add-pr-to-project/actions/runs/10277574831
> Failed to dispatch workflow - HTTP response code was 404

It's also resulted in patches having to be manually tagged.

## Issue
- https://github.com/silverstripe/.github/issues/290